### PR TITLE
[FEATURE] Add initial docker development configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,70 @@
+version: "3.8"
+
+services:
+  app: 
+    container_name: ranger_clubhouse_api
+    # build:
+    #   dockerfile: "./Dockerfile"
+    image: ranger-clubhouse-api:dev
+    user: ":1420"
+    depends_on:
+      - database
+    ports:
+      - "8000:80"
+    environment:
+      APP_NAME: "${APP_NAME:-Rangers Secret Clubhouse}"
+      APP_ENV: "${APP_ENV:-local}"
+      APP_KEY: "${APP_KEY}"
+      APP_URL: "${APP_URL:-http://localhost:8000}"
+      RANGER_CLUBHOUSE_ENVIRONMENT: "${RANGER_CLUBHOUSE_ENVIRONMENT:-Staging}"
+      RANGER_DB_HOST_NAME: "${RANGER_DB_HOST_NAME:-database}"
+      RANGER_DB_DATABASE_NAME: "${RANGER_DB_DATABASE_NAME:-rangers}"
+      RANGER_DB_USER_NAME: "${RANGER_DB_USER_NAME:-rangers}"
+      RANGER_DB_PASSWORD: "${RANGER_DB_PASSWORD:-donothing}"
+      RANGER_DB_CONNECTION: "${RANGER_DB_CONNECTION:-mysql}"
+      RANGER_DB_PORT: "${RANGER_DB_PORT:-3306}"
+    volumes:
+      - "./:/var/www/application"
+      - "./docker/nginx-default.conf:/etc/nginx/http.d/default.conf"
+    working_dir: /var/www/application
+    # command: "php artisan serve"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 1512M
+        reservations:
+          cpus: '1'
+          memory: 1512M
+
+  database:
+    container_name: ranger_clubhouse_database
+    image: mariadb:10.5.12
+    volumes:
+      - database:/var/lib/mysql
+    restart: unless-stopped
+    environment:
+      MARIADB_DATABASE: "${RANGER_DB_DATABASE_NAME:-rangers}"
+      MARIADB_USER: "${RANGER_DB_USER_NAME:-rangers}"
+      MARIADB_PASSWORD: "${RANGER_DB_PASSWORD:-donothing}"
+      MARIADB_ROOT_PASSWORD: "${RANGER_DB_ROOT_PASSWORD:-donothingdonothing}"
+
+  adminer:
+    container_name: ranger_clubhouse_adminer
+    image: adminer
+    environment:
+      ADMINER_DEFAULT_SERVER: ranger_clubhouse_database
+    depends_on:
+      - database
+    restart: unless-stopped
+    ports:
+      - 8089:8080
+
+volumes:
+  database:
+
+networks:
+  default:
+    name: "${DOCKER_RANGERS_NETWORK:-ranger-clubhouse}"

--- a/docker/nginx-default.conf
+++ b/docker/nginx-default.conf
@@ -26,7 +26,7 @@ server {
         }
 
         # Handle CORS requests - should only see this during development, not production.
-        if ($request_method = 'OPTIONS') {
+        # if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin'  '*';
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE, HEAD';
             add_header 'Access-Control-Max-Age:' '1728000';
@@ -35,7 +35,7 @@ server {
             add_header 'Content-Type' 'text/plain; charset=UTF-8';
             add_header 'Content-Length' '0';
             return 204;
-        }
+        # }
     }
 
     #


### PR DESCRIPTION
## Overview

Goal is to support faster development environment provisioning with a docker & docker-compose setup.

### WIP TODO

 - [ ] Organize docker files in `docker` directory
 - [ ] Add `caddy` reverse proxy with `ims.lvh.me` domain or similar
 - [ ] Optimize Dockerfile
 - [ ] Add `README` steps for development
 - [ ] Add ability to run linters & tests from compose commands